### PR TITLE
Fix setting offset mistake

### DIFF
--- a/boxy/lib/src/boxy/custom_boxy_base.dart
+++ b/boxy/lib/src/boxy/custom_boxy_base.dart
@@ -733,7 +733,7 @@ class BaseBoxyChild extends InflatedChildHandle {
     return _parent.wrapOffset(Offset(transform[12], transform[13]), size);
   }
 
-  set offset(Offset newOffset) => position(offset);
+  set offset(Offset newOffset) => position(newOffset);
 
   /// The matrix transformation applied to this child, used by [paint] and
   /// [hitTest].


### PR DESCRIPTION
Ultra simple mistake, now I know why `child.offset = x` never worked :D Should I add tests for this, please direct me where should I add that